### PR TITLE
Add exec to the nouns and add errorCode to the tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ function shim (dockerode, opts) {
         port: modem.post,
         dockerVersion: modem.version,
         success: err == null,
-        statusCode: err && err.statusCode
+        statusCode: err && err.statusCode,
+        errorCode: err && err.code
       });
       callback(err, payload);
     }
@@ -39,6 +40,7 @@ var dockerNouns = [
   'copy',
   'create',
   'events',
+  'exec',
   'export',
   'history',
   'images',


### PR DESCRIPTION
Add support for docker exec. Report `err.code` as a tag